### PR TITLE
Update benchmarking ahash dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ xxhash2 = "0.1"
 twox-hash = "1.1"
 seahash = "3.0"
 fxhash = "0.2"
-ahash = "0.1"
+ahash = "0.8"
 rustc-hash = "1.0"
 meowhash = "0.1"
 

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 extern crate criterion;
 
 use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hasher, BuildHasher};
+use std::hash::Hasher;
 use std::hash::SipHasher;
 use std::io::BufReader;
 use std::mem;
@@ -14,7 +14,7 @@ use std::slice;
 
 use criterion::{black_box, Criterion, ParameterizedBenchmark, Throughput};
 
-use ahash::ABuildHasher;
+use ahash::AHasher;
 use farmhash::{hash32_with_seed as farmhash32, hash64_with_seed as farmhash64};
 use fnv::FnvHasher;
 use fxhash::{hash32 as fxhash32, hash64 as fxhash64};
@@ -192,9 +192,8 @@ fn bench_hash64(c: &mut Criterion) {
                 b.iter(|| fxhash64(&DATA[..size]));
             })
             .with_function("ahash", move |b, &&size| {
-                let builder = ABuildHasher::new();
                 b.iter(|| {
-                    let mut h = builder.build_hasher();
+                    let mut h = AHasher::default();
                     h.write(&DATA[..size]);
                     h.finish()
                 });


### PR DESCRIPTION
The original dep has been yanked.

`criterion` is also out of date and has future incompatibility warnings, it would be nice to update that as well but it seems more involved.